### PR TITLE
Update testing doc references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /app/backend
 COPY backend/pyproject.toml backend/README.md backend/uv.lock ./
 
 # Create virtual environment and install dependencies
-RUN uv venv .venv && uv sync --no-dev
+RUN uv venv .venv && uv sync --group dev --group test
 
 # Production stage
 FROM python:3.11-slim AS production

--- a/docs/epic3-task-summary.md
+++ b/docs/epic3-task-summary.md
@@ -70,6 +70,17 @@ Comprehensive test suite created covering:
 - Error cases
 - Nested data retrieval
 
+The tests reside in `backend/tests/` and include:
+
+- **conftest.py** – reusable database fixtures
+- **test_archetypes.py** – archetype endpoints and powerset listing
+- **test_enhancements.py** – enhancement and enhancement-set endpoints
+- **test_powers.py** – power lookup, search, and filtering
+- **test_powersets.py** – powerset retrieval with nested powers
+
+Use `just test` to automatically sync backend dependencies with uv (including
+FastAPI and pytest) before running the suite.
+
 ### GitHub Issues Updated
 
 - ✅ Closed Task 3.1 subtasks (#38-42)

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ health:
 # Run all tests
 test:
     @echo "🧪 Running all tests..."
-    cd backend && {{uv}} run pytest -v
+    cd backend && {{uv}} sync --group dev --group test && {{uv}} run pytest -v
     cd frontend && npm test -- --watchAll=false
 
 # Run tests in watch mode


### PR DESCRIPTION
## Summary
- clarify which backend test modules cover the API
- ensure the just `test` recipe syncs dev & test dependencies
- install dev/test dependencies in Docker builder stage

## Testing
- `uv sync --group dev --group test`
- `uv run pytest -vv` *(fails: fastapi.exceptions.ResponseValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_68792d0e212c8328bc6a2623c4769927