### PR TITLE
Add agent templates and context isolation references

### DIFF
--- a/.claude/agents/database-specialist.json
+++ b/.claude/agents/database-specialist.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "description": "Database Specialist agent configuration",
+  "modules": [
+    ".claude/modules/database/guide.md",
+    ".claude/modules/database/schema-reference.md"
+  ],
+  "tool_loadout": {
+    "preferred_tools": ["Read", "Write", "Edit", "MultiEdit", "Bash", "LS"],
+    "preferred_commands": ["alembic", "psql", "just db-*"],
+    "avoid_tools": ["WebFetch", "WebSearch"]
+  },
+  "context_limit": 40000
+}

--- a/.claude/agents/frontend-specialist.json
+++ b/.claude/agents/frontend-specialist.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "description": "Frontend Specialist agent configuration",
+  "modules": [
+    ".claude/modules/frontend/guide.md",
+    ".claude/modules/frontend/architecture.md"
+  ],
+  "tool_loadout": {
+    "preferred_tools": ["Read", "Write", "Edit", "MultiEdit", "Bash"],
+    "preferred_commands": ["npm", "jest", "just frontend-*"],
+    "avoid_tools": ["Bash(psql:*)"]
+  },
+  "context_limit": 30000
+}

--- a/.claude/agents/import-specialist.json
+++ b/.claude/agents/import-specialist.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "description": "Import Specialist agent configuration",
+  "modules": [
+    ".claude/modules/import/guide.md",
+    ".claude/modules/import/commands-reference.md"
+  ],
+  "tool_loadout": {
+    "preferred_tools": ["Read", "Bash", "LS", "Grep"],
+    "preferred_commands": ["python", "just import-*", "just i12-*"],
+    "avoid_tools": ["Write", "Edit"]
+  },
+  "context_limit": 35000
+}

--- a/.claude/context-map.json
+++ b/.claude/context-map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Claude context loading rules and token limits",
-  "last_updated": "2025-01-19",
+  "last_updated": "2025-07-25",
   
   "token_limits": {
     "total_max": 128000,
@@ -168,6 +168,22 @@
       "preferred_commands": ["docker", "logs", "ps", "grep"],
       "avoid_tools": [],
       "context_hints": "Diagnostic focus, read-heavy"
+    }
+  },
+
+  "agents": {
+    "description": "Isolated agent contexts with separate state",
+    "database-specialist": {
+      "config": ".claude/agents/database-specialist.json",
+      "state_dir": ".claude/state/agents/database-specialist/"
+    },
+    "import-specialist": {
+      "config": ".claude/agents/import-specialist.json",
+      "state_dir": ".claude/state/agents/import-specialist/"
+    },
+    "frontend-specialist": {
+      "config": ".claude/agents/frontend-specialist.json",
+      "state_dir": ".claude/state/agents/frontend-specialist/"
     }
   },
   

--- a/.claude/docs/epic-2.5-implementation-plan.md
+++ b/.claude/docs/epic-2.5-implementation-plan.md
@@ -248,6 +248,21 @@ agent-database cmd:
   uv run --script .claude/scripts/database-agent.py "{{cmd}}"
 ```
 
+### Running and Switching Agents
+
+Each agent reads its configuration from `.claude/agents/{name}.json` and keeps
+logs under `.claude/state/agents/{name}/`. Use the matching `just` command to
+run a task with a given agent:
+
+```bash
+just agent-database "migrate"
+just agent-import "status"
+just agent-frontend "dev"
+```
+
+Switch agents by invoking a different command; previous agent context remains
+quarantined in its own state directory.
+
 ## 📅 Implementation Timeline
 
 ### Week 1: Session Summarization Foundation


### PR DESCRIPTION
## Summary
- create `.claude/agents/` with database, import, and frontend specialist templates
- reference the new agents from `context-map.json`
- document how to run and switch agents in the epic implementation plan

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687c97d7752c83289d8439fee00e6bee